### PR TITLE
Fix winner display fade animation

### DIFF
--- a/src/components/GiftRoulette.astro
+++ b/src/components/GiftRoulette.astro
@@ -123,9 +123,11 @@ import HistoryList from './HistoryList.astro';
     const pastelColor = getRandomPastelColor();
     nameDisplay.style.backgroundColor = pastelColor;
     nameDisplay.textContent = name;
+    nameDisplay.classList.remove("opacity-0");
     nameDisplay.classList.add("opacity-100");
     setTimeout(() => {
       nameDisplay.classList.remove("opacity-100");
+      nameDisplay.classList.add("opacity-0");
     }, 1500);
   }
 


### PR DESCRIPTION
## Summary
- fix the fade animation for the winner name/arrow

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68413697c8288321981c1c2e3e1e1548